### PR TITLE
.darkify() anchor style fix

### DIFF
--- a/src/nightly.js
+++ b/src/nightly.js
@@ -86,7 +86,7 @@ var Nightly = function(nightMode, nightCallback, dayCallback) {
     this.initialTheme = {
       body: document.body.style.backgroundColor,
       texts: document.body.style.color,
-      links: this.linkTags[0].style.color || '',
+      links: this.linkTags[0] ? this.linkTags[0].style.color : '',
       inputs: {
               color: this.inputTags[0] ? this.inputTags[0].style.color : '',
               backgroundColor: this.inputTags[0] ?


### PR DESCRIPTION
If no anchor tags were found within the DOM, the .darkify() method would through an error: "Uncaught TypeError: Cannot read property 'style' of undefined".  The method will now check if an anchor tag exists before retrieving it's initial value.